### PR TITLE
Do not store JSON documents as URL strings

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -169,11 +169,6 @@ function safeJSON (string) {
 }
 
 function onAnalyze (value) {
-  // For shareability purposes
-  const url = new URL(window.location.href)
-  url.searchParams.set('json', value)
-  window.history.replaceState({ value }, '', url.href)
-
   const jsonDocument = safeJSON(value)
   if (typeof jsonDocument === 'undefined') {
     document.getElementById('json-error').style.display = 'block'
@@ -186,10 +181,5 @@ function onAnalyze (value) {
 document.getElementById('analyze').addEventListener('click', () => {
   return onAnalyze(code.getValue())
 })
-
-const urlValue = new URL(window.location.href).searchParams.get('json')
-if (urlValue) {
-  code.setValue(urlValue)
-}
 
 onAnalyze(code.getValue())


### PR DESCRIPTION
Only works for small documents, otherwise the max URL size is hit and
the app breaks completely. I experimented with `localStorage`, but the
max quota there also imposes a too-strict limit on the document size.

Let's disable document saving for now.

See: https://github.com/sourcemeta/json-taxonomy/issues/4
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
